### PR TITLE
docs(contributing): require one branch per GitHub issue

### DIFF
--- a/.cursor/rules/git-branch-per-issue.mdc
+++ b/.cursor/rules/git-branch-per-issue.mdc
@@ -1,0 +1,21 @@
+---
+description: Use one Git branch per GitHub issue; never commit product changes directly to main without a PR.
+alwaysApply: true
+---
+
+# Git — branch per issue
+
+For **Indonesian-Game**:
+
+1. **Before coding:** Ensure there is a **GitHub Issue** for the work (or create one in the browser).
+2. **Branch from `main`:** Use a name that includes the issue number, for example:
+   - `issue-12-skill-tree-purchase`
+   - `feat/12-skill-tree-purchase` or `fix/12-typo-in-readme`
+3. **Do all commits on that branch** — not on `main`.
+4. **Commit messages:** Conventional Commits; put `Refs #12` (or `Fixes #12` when closing) in the **body**.
+5. **Open a Pull Request** into `main`; use `Closes #12` / `Fixes #12` in the PR description when the issue is fully done.
+6. **Merge** only via PR (squash or merge commit per team preference).
+
+**Exception:** Rare repo-only hotfixes may still go through a PR from a short-lived branch when possible.
+
+Do **not** push unrelated changes on the same branch; one focused PR per issue is preferred.

--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,10 @@ lerna-debug.log*
 *.sln
 *.sw?
 
-# Cursor (local; commit rules later explicitly if desired)
-.cursor/
+# Cursor — ignore local workspace cache; keep team rules under .cursor/rules/
+.cursor/*
+!.cursor/rules/
+!.cursor/rules/**
 
 # OS
 .DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,27 @@
 # Contributing
 
-## Workflow
+## Branch per issue (required)
+
+Do **not** commit product changes directly to `main`.
+
+1. Open (or pick) a **GitHub Issue** for the unit of work.
+2. From latest `main`, create a **dedicated branch** that includes the issue number:
+
+   | Style | Example |
+   |-------|---------|
+   | `issue-<n>-slug` | `issue-12-skill-tree-purchase` |
+   | `feat/<n>-slug` | `feat/12-add-ci-workflow` |
+   | `fix/<n>-slug` | `fix/3-readme-typo` |
+
+3. Implement and push **only** that branch; open a **Pull Request** to `main`.
+4. One issue → one focused branch → one PR (avoid mixing unrelated work).
+
+Cursor project rules under [`.cursor/rules/`](.cursor/rules/) reinforce this for AI-assisted work.
+
+## Workflow (detail)
 
 1. Open a **GitHub Issue** for the change (feature, bug, chore).
-2. Create a branch from `main`, e.g. `issue-12-short-slug` or `feat/12-short-slug`.
+2. `git checkout main` → `git pull` → `git checkout -b issue-<n>-short-description`
 3. Commit with [Conventional Commits](https://www.conventionalcommits.org/) and reference the issue in the **body**:
 
    ```text
@@ -14,6 +32,7 @@
 
 4. Open a **Pull Request**; use `Closes #12` or `Fixes #12` in the PR description when the issue is fully done.
 5. Merge via squash or merge commit; keep `Fixes #n` in the squash message body if GitHub should auto-close the issue.
+6. Delete the remote branch after merge if you like.
 
 ## Scope
 


### PR DESCRIPTION
Add CONTRIBUTING section, Cursor rule (alwaysApply), and gitignore exception for .cursor/rules/. Refs workflow plan.